### PR TITLE
Fix index function support

### DIFF
--- a/src/util/FirestoreHandler.ts
+++ b/src/util/FirestoreHandler.ts
@@ -113,7 +113,7 @@ export default class FirestoreCollectionHandler {
 
         const index =
           typeof this.reference.index === "function"
-            ? this.reference.index.call(this, snap, parentSnap)
+            ? this.reference.index.call(this, change.doc, parentSnap)
             : this.reference.index
 
         switch (changeType) {


### PR DESCRIPTION
I've added an ensureIndex method that is executed just before the switch logich in the handleSnapshot method, so the ES index name could be build properly.