### PR TITLE
Fix incorrect bind

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,30 @@
+{
+  "name": "elasticstore",
+  "version": "1.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
+    "source-map-support": "^0.5.19",
     "ts-jest": "^26.1.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import Elasticstore from "./elasticstore"
+import 'source-map-support/register'
 
 async function main() {
   const elasticstore = new Elasticstore()

--- a/src/util/FirestoreHandler.ts
+++ b/src/util/FirestoreHandler.ts
@@ -149,11 +149,11 @@ export default class FirestoreCollectionHandler {
     }
 
     try {
-      const exists = await Queuer.process(this.client.exists.bind(this, { id: doc.id, index }))
+      const exists = await Queuer.process(this.client.exists.bind(this.client, { id: doc.id, index }))
       if (exists) {
         // retryOnConflict added in reference to https://github.com/acupofjose/elasticstore/issues/2
         await Queuer.process(
-          this.client.update.bind(this, {
+          this.client.update.bind(this.client, {
             id: doc.id,
             index,
             body: { doc: body, doc_as_upsert: true },
@@ -165,7 +165,7 @@ export default class FirestoreCollectionHandler {
           await this.reference.onItemUpserted.call(this, body, doc, this.client)
         }
       } else {
-        await Queuer.process(this.client.index.bind(this, { id: doc.id, index, body: body }))
+        await Queuer.process(this.client.index.bind(this.client, { id: doc.id, index, body: body }))
 
         if (this.reference.onItemUpserted) {
           await this.reference.onItemUpserted.call(this, body, doc, this.client)
@@ -195,7 +195,7 @@ export default class FirestoreCollectionHandler {
     try {
       // retryOnConflict added in reference to https://github.com/acupajoe/elasticstore/issues/2
       await Queuer.process(
-        this.client.update.bind(this, {
+        this.client.update.bind(this.client, {
           id: doc.id,
           index,
           body: { doc: body },
@@ -215,7 +215,7 @@ export default class FirestoreCollectionHandler {
 
   private handleRemoved = async (doc: admin.firestore.DocumentSnapshot, index: string) => {
     try {
-      await Queuer.process(this.client.delete.bind(this, { id: doc.id, index }))
+      await Queuer.process(this.client.delete.bind(this.client, { id: doc.id, index }))
       console.log(`Removed [doc@${doc.id}]`)
     } catch (e) {
       console.error(`Error in \`FS_REMOVE\` handler [doc@${doc.id}]: ${e.message}`)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
     "module": "commonjs",
     "outDir": "lib",
     "lib": ["es2015"],
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "sourceMap": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "**/*.test.ts", "**/*.spec.ts"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -280,13 +280,13 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@elastic/elasticsearch@^7.8.0":
-  version "7.8.0"
-  resolved "https://registry.yarnpkg.com/@elastic/elasticsearch/-/elasticsearch-7.8.0.tgz#3f9ee54fe8ef79874ebd231db03825fa500a7111"
-  integrity sha512-rUOTNN1At0KoN0Fcjd6+J7efghuURnoMTB/od9EMK6Mcdebi6N3z5ulShTsKRn6OanS9Eq3l/OmheQY1Y+WLcg==
+"@elastic/elasticsearch@~7.10.0":
+  version "7.10.0"
+  resolved "https://registry.yarnpkg.com/@elastic/elasticsearch/-/elasticsearch-7.10.0.tgz#da105a9c1f14146f9f2cab4e7026cb7949121b8d"
+  integrity sha512-vXtMAQf5/DwqeryQgRriMtnFppJNLc/R7/R0D8E+wG5/kGM5i7mg+Hi7TM4NZEuXgtzZ2a/Nf7aR0vLyrxOK/w==
   dependencies:
     debug "^4.1.1"
-    decompress-response "^4.2.0"
+    hpagent "^0.1.1"
     ms "^2.1.1"
     pump "^3.0.0"
     secure-json-parse "^2.1.0"
@@ -1450,13 +1450,6 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
-decompress-response@^4.2.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-4.2.1.tgz#414023cc7a302da25ce2ec82d0d5238ccafd8986"
-  integrity sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==
-  dependencies:
-    mimic-response "^2.0.0"
-
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
@@ -2081,6 +2074,11 @@ hosted-git-info@^2.1.4:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
   integrity sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==
+
+hpagent@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/hpagent/-/hpagent-0.1.1.tgz#66f67f16e5c7a8b59a068e40c2658c2c749ad5e2"
+  integrity sha512-IxJWQiY0vmEjetHdoE9HZjD4Cx+mYTr25tR7JCxXaiI3QxW0YqYyM11KyZbHufoa/piWhMb2+D3FGpMgmA2cFQ==
 
 html-encoding-sniffer@^2.0.1:
   version "2.0.1"
@@ -3117,11 +3115,6 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-mimic-response@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.1.0.tgz#d13763d35f613d09ec37ebb30bac0469c0ee8f43"
-  integrity sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
-
 minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
@@ -3885,7 +3878,7 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.6:
+source-map-support@^0.5.19, source-map-support@^0.5.6:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==


### PR DESCRIPTION
**Problem**: When setting up elasticstore for the first time, I ran into the same issue as #41.

```
TypeError: Cannot read property 'request' of undefined at FirestoreCollectionHandler.existsApi
```

**Debugging**:
- Added `source-map-support` so the crashing stacktrace has `.ts` line numbers instead of `.js` line numbers. Part of this PR.
- Noticed error message mentions `FirestoreCollectionHandler.existsApi`. But the `FirestoreCollectionHandler` does not have a `existsApi` function. This indicated the function is being called on the wrong object.

**Fix**: The `bind` function on the elasticsearch client does not bind `this` correctly. `this` should be bound to the client object, not to the `FirestoreCollectionHandler` object. Same issue is also mentioned [here](https://github.com/elastic/elasticsearch-js/issues/574#issuecomment-379153897).

**Testing done**: Works on my self-hosted deployment. Errors no longer occur in logs. Confirmed data appears in elastic search.

```
Connecting to ElasticSearch host elastic-search:9200
Connected to ElasticSearch host elastic-search:9200
Connecting to Firebase https://${DB}.firebaseio.com
Listening on: 'search' for queries (in: query -> out: result)
Cleanup will happen in 60000

        Begin listening to changes for collection: users
          documentId: ${ID}
          subcollection: ${SUB}
          include: [  ]
          exclude: [  ]

Added [doc@...]
Added [doc@...]
Added [doc@...]
```

Fixes #41